### PR TITLE
use_logo: correct the issue about 'hide-logo'

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Suggests:
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.0.2
+RoxygenNote: 7.1.0

--- a/R/use_logo.R
+++ b/R/use_logo.R
@@ -41,7 +41,7 @@ use_logo <- function(
   height = "128px",
   position = css_position(top = "1em", right = "1em"),
   link_url = NULL,
-  exclude_class = c("title-slide", "inverse", "hide_logo")
+  exclude_class = c("title-slide", "inverse", "hide-logo")
 ) {
 	htmltools::tagList(
 		html_dependency_logo(link_url, exclude_class),

--- a/man/logo.Rd
+++ b/man/logo.Rd
@@ -12,7 +12,7 @@ use_logo(
   height = "128px",
   position = css_position(top = "1em", right = "1em"),
   link_url = NULL,
-  exclude_class = c("title-slide", "inverse", "hide_logo")
+  exclude_class = c("title-slide", "inverse", "hide-logo")
 )
 
 html_dependency_logo(
@@ -41,7 +41,7 @@ class are excluded.}
 \item{inline}{In \code{\link[=html_dependency_logo]{html_dependency_logo()}}, should the JS and CSS code to
 create the logo be returned inline (inside the rendered slides) or in
 separate CSS and JS documents attacheds as an html dependency? The default
-is to use inline for \pkg{xaringan} version 0.16 or later.}
+is to use inline for \pkg{xaringan} version 0.17 or later.}
 }
 \value{
 An \code{htmltools::tagList()} with the Add Logo dependencies, or an

--- a/man/text_poster.Rd
+++ b/man/text_poster.Rd
@@ -74,13 +74,10 @@ need to call this function.
 \section{Usage}{
  To add text-poster to your xaringan presentation, use
 \code{text_poster()} to create a block of poster text. Include line breaks in
-the text string to split the text block.\if{html}{\out{<div class="{r poster-text, echo=FALSE}">}}\preformatted{xaringanExtra::text_poster(
-  "There are no
-  routine statistical
-  questions, only questionable
-  statistical routines."
-)
-}\if{html}{\out{</div>}}\preformatted{}
+the text string to split the text block. <!--html_preserve--><div class="text-poster" style="width:100\%;height:100\%;padding:1em;">
+<div class="text-poster__text" data-text="There are no&#10;  routine statistical&#10;  questions, only questionable&#10;  statistical routines."></div>
+</div><!--/html_preserve-->
+  ````
 }
 
 \references{


### PR DESCRIPTION
The doc says adding 'hide-logo' to suppress the logo, but the function says 'hide_logo'.