### PR TITLE
Minor improvements for scribble

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: xaringanExtra
 Title: Extras And Extensions for Xaringan Slides
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: 
     c(person(given = "Garrick",
              family = "Aden-Buie",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# xaringanExtra 0.3.1 (2021-03-13)
+
+* **Breaking change:** scribble now only accepts hexadecimal pen colors. You
+  can still use `rgb()` syntax by calling the `rgb()` function in R: instead of
+  `"rgb(61, 255, 232)"`, you can write `rgb(61, 255, 232, maxColorValue = 255)`.
+* Fix a few other minor issues with **scrible**:
+    - Fix toolbox unminimizing after mouseover when it should stay minimized
+    - Don't show the eraser cursor until the mouse moves
+
 # xaringanExtra 0.3.0 (2021-03-07)
 
 - New addin: **scribble**! Now you can draw on your slides! Huge thanks to

--- a/R/scribble.R
+++ b/R/scribble.R
@@ -20,8 +20,8 @@
 #'   ```
 #'   ````
 #'
-#' @param pen_color Initial pen color (default is `"#FF0000` (red)). May be any
-#'   valid CSS Hex, RGB, or HSL color.
+#' @param pen_color Initial pen color (default is `"#FF0000` (red)). Must be a
+#'   hexadecimal color, e.g. `#000` or `#4232ea`.
 #' @param pen_size Pen size (default is 3).
 #' @param eraser_size Eraser size (default is `pen_size * 10`).
 #'
@@ -98,7 +98,8 @@ init_scribble <- function(
   # Current we expect one color, we may lift this restriction in the future
   stopifnot(
     "single pen color" = length(pen_color) == 1,
-    "pen_color must be character" = is.character(pen_color)
+    "pen_color must be character" = is.character(pen_color),
+  	"pen_color must be a hexadecimal color" = all(is_hex_color(pen_color))
   )
   stopifnot(is.numeric(pen_size))
   stopifnot(is.numeric(eraser_size))
@@ -116,4 +117,9 @@ init_scribble <- function(
     ),
     opts
   )
+}
+
+is_hex_color <- function(x) {
+  x <- trimws(x)
+  grepl("^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$", x)
 }

--- a/docs/NEWS.md
+++ b/docs/NEWS.md
@@ -1,3 +1,12 @@
+# xaringanExtra 0.3.1 (2021-03-13)
+
+* **Breaking change:** scribble now only accepts hexadecimal pen colors. You
+  can still use `rgb()` syntax by calling the `rgb()` function in R: instead of
+  `"rgb(61, 255, 232)"`, you can write `rgb(61, 255, 232, maxColorValue = 255)`.
+* Fix a few other minor issues with **scrible**:
+    - Fix toolbox unminimizing after mouseover when it should stay minimized
+    - Don't show the eraser cursor until the mouse moves
+
 # xaringanExtra 0.3.0 (2021-03-07)
 
 - New addin: **scribble**! Now you can draw on your slides! Huge thanks to

--- a/docs/panelset/rmarkdown.html
+++ b/docs/panelset/rmarkdown.html
@@ -167,7 +167,7 @@ pre code {
 
 
 <h1 class="title toc-ignore">Panelset in R Markdown</h1>
-<h3 class="subtitle">xaringanExtra 0.3.0</h3>
+<h3 class="subtitle">xaringanExtra 0.3.1</h3>
 <h4 class="author"><a href="https://pkg.garrickadenbuie.com/xaringanExtra" class="uri">https://pkg.garrickadenbuie.com/xaringanExtra</a></h4>
 
 </div>

--- a/docs/scribble/index.Rmd
+++ b/docs/scribble/index.Rmd
@@ -79,7 +79,7 @@ xaringanExtra::use_scribble()
 ````
 
 ```{r xaringanExtra-scribble, echo=FALSE}
-xaringanExtra::use_scribble()
+xaringanExtra::use_scribble(rgb(0.9, 0.5, 0.5))
 ```
 
 --

--- a/docs/scribble/index.html
+++ b/docs/scribble/index.html
@@ -10,7 +10,7 @@
     <script src="libs/fabric/fabric.min.js"></script>
     <link href="libs/xaringanExtra-scribble/scribble.css" rel="stylesheet" />
     <script src="libs/xaringanExtra-scribble/scribble.js"></script>
-    <script>document.addEventListener('DOMContentLoaded', function() { window.xeScribble = new Scribble({"pen_color":["#FF0000"],"pen_size":3,"eraser_size":30}) })</script>
+    <script>document.addEventListener('DOMContentLoaded', function() { window.xeScribble = new Scribble({"pen_color":["#E68080"],"pen_size":3,"eraser_size":30}) })</script>
     <link rel="preconnect" href="https://fonts.gstatic.com">
     <link href="https://fonts.googleapis.com/css2?family=Gaegu&family=Permanent+Marker&family=Pangolin&display=swap" rel="stylesheet">
 

--- a/docs/scribble/libs/xaringanExtra-scribble/scribble.js
+++ b/docs/scribble/libs/xaringanExtra-scribble/scribble.js
@@ -470,7 +470,6 @@ class Scribble {
     this.eraseMode = true
     this.drawMode = false
     this.eraseBtn.title = 'Stop Erasing'
-    this.eraserCursor.classList.remove('hidden')
     this.eraserCursor.style.backgroundColor = this.eraserColor()
     this.colorPicker.classList.add('hidden')
 
@@ -480,6 +479,13 @@ class Scribble {
 
     document.addEventListener('mousemove', this.eraserCursorMovement)
     document.addEventListener('touchmove', this.eraserCursorMovement)
+
+    const self = this
+    ;['mousemove', 'touchmove'].forEach(function (action) {
+      document.addEventListener(action, function (ev) {
+        self.eraserCursor.classList.remove('hidden')
+      }, { once: true })
+    })
 
     document.addEventListener('keydown', this.undo)
     document.addEventListener('keydown', this.redo)

--- a/docs/scribble/libs/xaringanExtra-scribble/scribble.js
+++ b/docs/scribble/libs/xaringanExtra-scribble/scribble.js
@@ -229,7 +229,7 @@ class Scribble {
     if (color.substr(0, 1) === '#') {
       return color
     }
-    const digits = /rgb\((\d+), (\d+), (\d+)\)/.exec(color)
+    const digits = /rgb\((\d+),\s*(\d+),\s*(\d+)/.exec(color)
 
     const red = parseInt(digits[1])
     const green = parseInt(digits[2])

--- a/docs/scribble/libs/xaringanExtra-scribble/scribble.js
+++ b/docs/scribble/libs/xaringanExtra-scribble/scribble.js
@@ -314,7 +314,7 @@ class Scribble {
 
   toggleToolbox (show) {
     const isMinimized = this.toolBox.matches('.minimized')
-    if (show && show === !isMinimized) return
+    if (typeof show !== 'undefined' && show === !isMinimized) return
 
     this.hideToolbox = !(show || isMinimized)
     this.toolBox.classList.toggle('minimized')

--- a/docs/share-again/index.html
+++ b/docs/share-again/index.html
@@ -167,7 +167,7 @@ pre code {
 
 <h1 class="title toc-ignore">Share Again</h1>
 <h4 class="author">xaringanExtra</h4>
-<h4 class="date">0.3.0</h4>
+<h4 class="date">0.3.1</h4>
 
 </div>
 

--- a/inst/scribble/scribble.js
+++ b/inst/scribble/scribble.js
@@ -470,7 +470,6 @@ class Scribble {
     this.eraseMode = true
     this.drawMode = false
     this.eraseBtn.title = 'Stop Erasing'
-    this.eraserCursor.classList.remove('hidden')
     this.eraserCursor.style.backgroundColor = this.eraserColor()
     this.colorPicker.classList.add('hidden')
 
@@ -480,6 +479,13 @@ class Scribble {
 
     document.addEventListener('mousemove', this.eraserCursorMovement)
     document.addEventListener('touchmove', this.eraserCursorMovement)
+
+    const self = this
+    ;['mousemove', 'touchmove'].forEach(function (action) {
+      document.addEventListener(action, function (ev) {
+        self.eraserCursor.classList.remove('hidden')
+      }, { once: true })
+    })
 
     document.addEventListener('keydown', this.undo)
     document.addEventListener('keydown', this.redo)

--- a/inst/scribble/scribble.js
+++ b/inst/scribble/scribble.js
@@ -229,7 +229,7 @@ class Scribble {
     if (color.substr(0, 1) === '#') {
       return color
     }
-    const digits = /rgb\((\d+), (\d+), (\d+)\)/.exec(color)
+    const digits = /rgb\((\d+),\s*(\d+),\s*(\d+)/.exec(color)
 
     const red = parseInt(digits[1])
     const green = parseInt(digits[2])

--- a/inst/scribble/scribble.js
+++ b/inst/scribble/scribble.js
@@ -314,7 +314,7 @@ class Scribble {
 
   toggleToolbox (show) {
     const isMinimized = this.toolBox.matches('.minimized')
-    if (show && show === !isMinimized) return
+    if (typeof show !== 'undefined' && show === !isMinimized) return
 
     this.hideToolbox = !(show || isMinimized)
     this.toolBox.classList.toggle('minimized')

--- a/man/scribble.Rd
+++ b/man/scribble.Rd
@@ -14,8 +14,8 @@ html_dependency_fabricjs(minimized = TRUE)
 html_dependency_scribble(pen_color, pen_size, eraser_size)
 }
 \arguments{
-\item{pen_color}{Initial pen color (default is \verb{"#FF0000} (red)). May be any
-valid CSS Hex, RGB, or HSL color.}
+\item{pen_color}{Initial pen color (default is \verb{"#FF0000} (red)). Must be a
+hexadecimal color, e.g. \verb{#000} or \verb{#4232ea}.}
 
 \item{pen_size}{Pen size (default is 3).}
 

--- a/tests/testthat/test-scribble.R
+++ b/tests/testthat/test-scribble.R
@@ -17,6 +17,7 @@ describe("use_scribble()", {
     expect_error(use_scribble(pen_color = 12))
     expect_error(use_scribble(pen_size = "three"))
     expect_error(use_scribble(eraser_size = "thirty"))
+    expect_error(use_scribble(pen_color = "rgb(0, 0, 0)"))
   })
 })
 
@@ -33,4 +34,19 @@ describe("init_scribble()", {
     expect_snapshot(init_scribble("#FF00FF", pen_size = 4))
     expect_snapshot(init_scribble(pen_size = 4, eraser_size = 33))
   })
+})
+
+test_that("is_hex_color()", {
+  expect_true(is_hex_color("#fff"))
+  expect_true(is_hex_color("#FFF"))
+  expect_true(is_hex_color("#444"))
+  expect_true(is_hex_color("#012345"))
+  expect_true(is_hex_color("#67abcd"))
+  expect_true(is_hex_color("#123456ab"))
+  expect_false(is_hex_color("#1234"))
+  expect_false(is_hex_color("#12345"))
+  expect_false(is_hex_color("#1234567"))
+  expect_false(is_hex_color("rgb(0, 0, 0)"))
+  expect_false(is_hex_color("rgba(0, 0, 0, 10%)"))
+  expect_false(is_hex_color("hsl(0, 0, 0, 10%)"))
 })


### PR DESCRIPTION
- [scribble] Only allow hexadecimal pen colors
- [scribble] Fix accidental unminimizing after mouseover
- [scribble] Don't show eraser cursor until mouse move

Fixes #95

The biggest change here is to only accept hexadecimal colors for the pen color. This is less than optimal, but unfortunately, it's easiest to catch and process this on the R side rather than the JavaScript side. I explored a few options, but we would have to bring in another JavaScript library to properly handle all of the many color format variations.

It's also not the worst inconvenience: instead of writing `"rgb(61, 255, 232)"`, a user would need to write `rgb(61, 255, 232, max = 255)`.

