### PR TITLE
Re-use use_logo for multiple logos/multiple rules templates

### DIFF
--- a/R/use_logo.R
+++ b/R/use_logo.R
@@ -45,8 +45,8 @@ use_logo <- function(
   logo_class = "xaringan-extra-logo",
   position = css_position(top = "1em", right = "1em"),
   link_url = NULL,
-  exclude_class = c("title-slide", "inverse", "hide_logo")
-) {
+  exclude_class = c("title-slide", "inverse", "hide_logo")){
+
 	htmltools::div(
 		htmltools::tags$style(
 			type = "text/css",
@@ -54,7 +54,7 @@ use_logo <- function(
 				logo_css(image_url, width, height, position, logo_class)
 			)
 		),
-		html_dependency_logo(link_url, logo_class, exclude_class)
+		html_dependency_logo(link_url, exclude_class, logo_class)
 	)
 }
 
@@ -133,7 +133,7 @@ html_dependency_logo <- function(
   htmltools::tagList(ret)
 }
 
-logo_css <- function(url, width, height, position, logo_class = "xaringan-extra-logo") {
+logo_css <- function(url, width, height, position, logo_class) {
   if (!is_css_position(position)) {
     stop("Please use `css_position()` to specify the position of your logo", call. = FALSE)
   }
@@ -145,19 +145,22 @@ logo_css <- function(url, width, height, position, logo_class = "xaringan-extra-
   width <- htmltools::validateCssUnit(width)
   height <- htmltools::validateCssUnit(height)
   sprintf(".%s {
-width: %s;
-height: %s;
-z-index: 0;
-background-image: url(%s);
-background-size: contain;
-background-repeat: no-repeat;
-position: absolute;
-%s%s%s%s
-}
-", logo_class, width, height, url, p$top, p$right, p$bottom, p$left)
+          width: %s;
+          height: %s;
+          z-index: 0;
+          background-image: url(%s);
+          background-size: contain;
+          background-repeat: no-repeat;
+          position: absolute;
+          %s%s%s%s
+          }",
+          logo_class, width, height, url, p$top, p$right, p$bottom, p$left)
 }
 
-logo_js <- function(link_url, exclude_class = c("title-slide", "inverse", "hide_logo"), logo_class = "xaringan-extra-logo") {
+logo_js <- function(link_url,
+                    exclude_class = c("title-slide", "inverse", "hide_logo"),
+                    logo_class = "xaringan-extra-logo") {
+
   element <- if (!is.null(link_url)) 'a' else 'div'
   link <- if (!is.null(link_url)) sprintf("'%s'", link_url) else "null"
 
@@ -192,5 +195,5 @@ logo_js <- function(link_url, exclude_class = c("title-slide", "inverse", "hide_
   }
   document.addEventListener('DOMContentLoaded', addLogo)
 })()",
-    exclude_class, element, logo_class, link)
+  exclude_class, element, logo_class, link)
 }

--- a/R/use_logo.R
+++ b/R/use_logo.R
@@ -36,11 +36,13 @@ NULL
 #'   class are excluded.
 #' @param width Width in CSS units of the logo
 #' @param height Height in CSS units of the logo
+#' @param logo_class Optionnally choose a class name for your logo, if you need more than one
 #' @export
 use_logo <- function(
   image_url,
   width = "110px",
   height = "128px",
+  logo_class = "xaringan-extra-logo",
   position = css_position(top = "1em", right = "1em"),
   link_url = NULL,
   exclude_class = c("title-slide", "inverse", "hide_logo")
@@ -49,10 +51,10 @@ use_logo <- function(
 		htmltools::tags$style(
 			type = "text/css",
 			htmltools::HTML(
-				logo_css(image_url, width, height, position)
+				logo_css(image_url, width, height, position, logo_class)
 			)
 		),
-		html_dependency_logo(link_url, exclude_class)
+		html_dependency_logo(link_url, logo_class, exclude_class)
 	)
 }
 
@@ -105,11 +107,12 @@ is_css_position <- function(x) {
 html_dependency_logo <- function(
 	link_url = NULL,
   exclude_class = c("title-slide", "inverse", "hide_logo"),
+  logo_class = "xaringan-extra-logo",
 	inline = NULL
 ) {
 	inline <- inline %||% xaringan_version("0.16")
 
-	logo_code_js <- logo_js(link_url, exclude_class)
+	logo_code_js <- logo_js(link_url, exclude_class, logo_class)
 
 	ret <- if (inline) {
 		htmltools::HTML(paste0("<script>", logo_code_js, "</script>"))
@@ -130,7 +133,7 @@ html_dependency_logo <- function(
   htmltools::tagList(ret)
 }
 
-logo_css <- function(url, width, height, position) {
+logo_css <- function(url, width, height, position, logo_class = "xaringan-extra-logo") {
   if (!is_css_position(position)) {
     stop("Please use `css_position()` to specify the position of your logo", call. = FALSE)
   }
@@ -141,7 +144,7 @@ logo_css <- function(url, width, height, position) {
   })
   width <- htmltools::validateCssUnit(width)
   height <- htmltools::validateCssUnit(height)
-  sprintf(".xaringan-extra-logo {
+  sprintf(".%s {
 width: %s;
 height: %s;
 z-index: 0;
@@ -151,10 +154,10 @@ background-repeat: no-repeat;
 position: absolute;
 %s%s%s%s
 }
-", width, height, url, p$top, p$right, p$bottom, p$left)
+", logo_class, width, height, url, p$top, p$right, p$bottom, p$left)
 }
 
-logo_js <- function(link_url, exclude_class = c("title-slide", "inverse", "hide_logo")) {
+logo_js <- function(link_url, exclude_class = c("title-slide", "inverse", "hide_logo"), logo_class = "xaringan-extra-logo") {
   element <- if (!is.null(link_url)) 'a' else 'div'
   link <- if (!is.null(link_url)) sprintf("'%s'", link_url) else "null"
 
@@ -181,7 +184,7 @@ logo_js <- function(link_url, exclude_class = c("title-slide", "inverse", "hide_
       document.querySelectorAll('.remark-slide-content%s')
         .forEach(function (slide) {
           const logo = document.createElement('%s')
-          logo.classList = 'xaringan-extra-logo'
+          logo.classList = '%s'
           logo.href = %s
           slide.appendChild(logo)
         })
@@ -189,5 +192,5 @@ logo_js <- function(link_url, exclude_class = c("title-slide", "inverse", "hide_
   }
   document.addEventListener('DOMContentLoaded', addLogo)
 })()",
-    exclude_class, element, link)
+    exclude_class, element, logo_class, link)
 }

--- a/man/logo.Rd
+++ b/man/logo.Rd
@@ -10,6 +10,7 @@ use_logo(
   image_url,
   width = "110px",
   height = "128px",
+  logo_class = "xaringan-extra-logo",
   position = css_position(top = "1em", right = "1em"),
   link_url = NULL,
   exclude_class = c("title-slide", "inverse", "hide_logo")
@@ -18,6 +19,7 @@ use_logo(
 html_dependency_logo(
   link_url = NULL,
   exclude_class = c("title-slide", "inverse", "hide_logo"),
+  logo_class = "xaringan-extra-logo",
   inline = NULL
 )
 }
@@ -28,6 +30,8 @@ a full URL or the path to the image relative to your slides file.}
 \item{width}{Width in CSS units of the logo}
 
 \item{height}{Height in CSS units of the logo}
+
+\item{logo_class}{Optionnally choose a class name for your logo, if you need more than one}
 
 \item{position}{The position of the logo from the sides of the slide. Use
 \code{\link[=css_position]{css_position()}} to specify.}


### PR DESCRIPTION
Disclaimer: This is my first ever pull request so please feel free to dunk me for all the things I have certainly missed and the etiquette I am not following: I am very eager to learn! Also, I love your package so much 😄 

Hello,

I work for a french public health/government organisation and we have a very strict ppt template to follow. I am allowed to pursue the use of html slides but only if I use the official template ([example here](https://www.atih.sante.fr/sites/default/files/public/content/2952/presentation_synthetique_enc_2017.pdf), although you shouldn't look it will make your eyes bleed).  

Up until today and diving into the `use_logo()` function from your package, I was stuck on a simple problem: our template has different background images/logos depending on the slide ...  And if I made CSS rules for slide classes using `background-image` property, then I couldn't use `background-image` when I needed it for presentation purposes (at least my users wouldn't understand why the logos suddenly disapeared).

I tried your package but using the function twice resulted in the last call erasing the first so I went ahead and slightly changed some arguments to allow for the naming of the added image and thus adding as many divs as needed !   

PS: if you took a look at the example ppt format (again, I advise against it for your eyes safety), the images that I need to change are vertical colored bars. I figured I also could use a variation of [what you did there](https://www.garrickadenbuie.com/blog/xaringan-tip-logo-all-slides/) (before use_logo existed I guess?) to add spans with a colored background but I don't know if thats a better way of doing things in HTML ...  

Have a great day 

Raphaël