### PR TITLE
[panelset] Use source hooks to restore line highlighting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -79,6 +79,7 @@ Imports:
     utils,
     uuid
 Suggests: 
+    callr,
     rmarkdown,
     testthat (>= 2.1.0),
     xaringan

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,9 @@
   
 * The `panelset=TRUE` chunk option now automatically sets `results="hold"`
   unless over-ridden by a local chunk option.
+  
+* panelset now uses the xaringan knitr source hooks, restoring line highlighting
+  in the source panel of panelset chunks. (#138)
 
 # xaringanExtra 0.5.0 (2021-06-13)
 

--- a/tests/testthat/test-panelset.R
+++ b/tests/testthat/test-panelset.R
@@ -71,14 +71,19 @@ describe("panelset_source_opts()", {
 
 render_slide_text <- function(rmd) {
   tmpfile <- tempfile(fileext = ".Rmd")
+  on.exit(unlink(tmpfile))
   rmd <- c("---", "title: test", "---", "", rmd)
   writeLines(rmd, tmpfile)
-  rmarkdown::render(
-    tmpfile,
-    output_file = "slides.html",
-    output_format = xaringan::moon_reader(seal = FALSE),
-    quiet = TRUE
-  )
+
+  callr::r_safe(function(tmpfile) {
+    rmarkdown::render(
+      tmpfile,
+      output_file = "slides.html",
+      output_format = xaringan::moon_reader(seal = FALSE),
+      quiet = TRUE
+    )
+  }, list(tmpfile = tmpfile))
+
   extract_slides_text(file.path(dirname(tmpfile), "slides.html"))
 }
 

--- a/tests/testthat/test-panelset.R
+++ b/tests/testthat/test-panelset.R
@@ -92,6 +92,7 @@ extract_slides_text <- function(path) {
   idx <- grep("^\\s*</?textarea", txt)
   txt <- txt[(idx[1] + 1):(idx[2] - 1)]
   txt <- paste(txt, collapse = "\n")
+  txt <- gsub("\n\n+", "\n\n", txt)
   trimws(txt)
 }
 
@@ -189,19 +190,6 @@ test_that("panelset knitr chunks with mutiple outputs", {
         "",
         "```r",
         "print(\"Oak is strong and also gives shade.\")",
-        "```",
-        "",
-        "]",
-        "",
-        ".panel[.panel-name[Output]",
-        "",
-        "```",
-        "## [1] \"Oak is strong and also gives shade.\"",
-        "```",
-        "",
-        ".panel[.panel-name[Code]",
-        "",
-        "```r",
         "print(\"The lake sparkled in the red hot sun.\")",
         "```",
         "",
@@ -210,10 +198,9 @@ test_that("panelset knitr chunks with mutiple outputs", {
         ".panel[.panel-name[Output]",
         "",
         "```",
+        "## [1] \"Oak is strong and also gives shade.\"",
         "## [1] \"The lake sparkled in the red hot sun.\"",
         "```",
-        "",
-        "",
         "",
         "]"
       ),


### PR DESCRIPTION
Fixes #99 by using the knitr source hooks in the panelset source hooks.

Also some minor refactoring to more cleanly set the `results` chunk option for panelset chunks.
