### PR TITLE
panelset: Support fenced panelset div around subsections

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,13 @@
 * **panelset** now works even better in Quarto documents, using the same syntax
   as [used for panelsets in R Markdown documents](http://pkg.garrickadenbuie.com/xaringanExtra/#/panelset?id=use-in-r-markdown) (#190).
 
+* **panelset** now supports a [fenced div](https://pandoc.org/MANUAL.html#extension-fenced_divs)
+  syntax where `::: {.panelset}` is used to start a panelset and each panel is
+  defined by a new heading within the fenced div. When used in this way, the
+  heading level of the subsections is ignored, the highest level subsection
+  heading within the fenced div determines the section level that creates a new
+  panel (#191).
+
 # xaringanExtra 0.7.0
 
 * BREAKING CHANGE: All arguments to `use_banner()` must be named. `use_banner()`

--- a/docs/NEWS.md
+++ b/docs/NEWS.md
@@ -3,6 +3,13 @@
 * **panelset** now works even better in Quarto documents, using the same syntax
   as [used for panelsets in R Markdown documents](http://pkg.garrickadenbuie.com/xaringanExtra/#/panelset?id=use-in-r-markdown) ([#190](https://github.com/gadenbuie/xaringanExtra/issues/190)).
 
+* **panelset** now supports a [fenced div](https://pandoc.org/MANUAL.html#extension-fenced_divs)
+  syntax where `::: {.panelset}` is used to start a panelset and each panel is
+  defined by a new heading within the fenced div. When used in this way, the
+  heading level of the subsections is ignored, the highest level subsection
+  heading within the fenced div determines the section level that creates a new
+  panel ([#191](https://github.com/gadenbuie/xaringanExtra/issues/191)).
+
 # xaringanExtra 0.7.0
 
 * BREAKING CHANGE: All arguments to `use_banner()` must be named. `use_banner()`

--- a/docs/panelset/libs/panelset/panelset.js
+++ b/docs/panelset/libs/panelset/panelset.js
@@ -215,11 +215,28 @@
     const initPanelSet = (panelset, idx) => {
       let panels = Array.from(panelset.querySelectorAll('.panel'))
       const pandocSectionSelector = ':is(section, .section)[class*="level"]'
-      if (!panels.length && panelset.matches(pandocSectionSelector)) {
-        // we're in tabset-alike R Markdown
-        const panelsetLevel = [...panelset.classList]
-          .filter(s => s.match(/^level/))[0]
-          .replace('level', '')
+      if (!panels.length) {
+        // we're in tabset-alike R Markdown or Quarto
+        const getSectionLevel = (el) => {
+          const levels = [...el.classList].filter(s => s.match(/^level/))
+          return levels.length ? levels[0].replace('level', '') : levels
+        }
+
+        // {.panelset} applied to a section heading
+        let panelsetLevel = getSectionLevel(panelset)
+
+        if (!panelsetLevel.length) {
+          // {.panelset} applied as a fenced div around subsections
+          const subSections = panelset.querySelectorAll(pandocSectionSelector)
+          if (!subSections.length) return
+
+          panelsetLevel = Array.from(subSections)
+            .map(getSectionLevel)
+            .map(x => parseInt(x))
+            .reduce((acc, x) => Math.min(acc, x), Infinity)
+
+          panelsetLevel = +panelsetLevel - 1
+        }
 
         // move children that aren't inside a section up above the panelset
         Array.from(panelset.children).forEach(function (el) {

--- a/docs/panelset/rmarkdown.html
+++ b/docs/panelset/rmarkdown.html
@@ -635,11 +635,28 @@ text-align: right;
     const initPanelSet = (panelset, idx) => {
       let panels = Array.from(panelset.querySelectorAll('.panel'))
       const pandocSectionSelector = ':is(section, .section)[class*="level"]'
-      if (!panels.length && panelset.matches(pandocSectionSelector)) {
-        // we're in tabset-alike R Markdown
-        const panelsetLevel = [...panelset.classList]
-          .filter(s => s.match(/^level/))[0]
-          .replace('level', '')
+      if (!panels.length) {
+        // we're in tabset-alike R Markdown or Quarto
+        const getSectionLevel = (el) => {
+          const levels = [...el.classList].filter(s => s.match(/^level/))
+          return levels.length ? levels[0].replace('level', '') : levels
+        }
+
+        // {.panelset} applied to a section heading
+        let panelsetLevel = getSectionLevel(panelset)
+
+        if (!panelsetLevel.length) {
+          // {.panelset} applied as a fenced div around subsections
+          const subSections = panelset.querySelectorAll(pandocSectionSelector)
+          if (!subSections.length) return
+
+          panelsetLevel = Array.from(subSections)
+            .map(getSectionLevel)
+            .map(x => parseInt(x))
+            .reduce((acc, x) => Math.min(acc, x), Infinity)
+
+          panelsetLevel = +panelsetLevel - 1
+        }
 
         // move children that aren't inside a section up above the panelset
         Array.from(panelset.children).forEach(function (el) {

--- a/inst/panelset/panelset.js
+++ b/inst/panelset/panelset.js
@@ -215,11 +215,28 @@
     const initPanelSet = (panelset, idx) => {
       let panels = Array.from(panelset.querySelectorAll('.panel'))
       const pandocSectionSelector = ':is(section, .section)[class*="level"]'
-      if (!panels.length && panelset.matches(pandocSectionSelector)) {
-        // we're in tabset-alike R Markdown
-        const panelsetLevel = [...panelset.classList]
-          .filter(s => s.match(/^level/))[0]
-          .replace('level', '')
+      if (!panels.length) {
+        // we're in tabset-alike R Markdown or Quarto
+        const getSectionLevel = (el) => {
+          const levels = [...el.classList].filter(s => s.match(/^level/))
+          return levels.length ? levels[0].replace('level', '') : levels
+        }
+
+        // {.panelset} applied to a section heading
+        let panelsetLevel = getSectionLevel(panelset)
+
+        if (!panelsetLevel.length) {
+          // {.panelset} applied as a fenced div around subsections
+          const subSections = panelset.querySelectorAll(pandocSectionSelector)
+          if (!subSections.length) return
+
+          panelsetLevel = Array.from(subSections)
+            .map(getSectionLevel)
+            .map(x => parseInt(x))
+            .reduce((acc, x) => Math.min(acc, x), Infinity)
+
+          panelsetLevel = +panelsetLevel - 1
+        }
 
         // move children that aren't inside a section up above the panelset
         Array.from(panelset.children).forEach(function (el) {


### PR DESCRIPTION
Supports additional syntax variation of a panelset fenced div around subsections:

````markdown
::: panelset

## One

Pariatur dolor est pariatur excepteur ad consectetur anim veniam sit ad laboris ad commodo Lorem.

## Two

Exercitation proident consequat velit officia irure incididunt veniam.
:::
````