### PR TITLE
Maintenance and upkeep of panelset CSS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,11 @@
   heading within the fenced div determines the section level that creates a new
   panel (#191).
 
+* **panelset** CSS was revamped for better ergonomics, in particular to improve
+  how the border bottom separating the tabs from the content and the bottom
+  border of the active tab are handled. `style_panelset_tabs()` gains a new
+  `separator_color` argument to replace `tabs_border_bottom` (#192).
+
 # xaringanExtra 0.7.0
 
 * BREAKING CHANGE: All arguments to `use_banner()` must be named. `use_banner()`

--- a/R/panelset.R
+++ b/R/panelset.R
@@ -61,8 +61,9 @@ use_panelset <- function(in_xaringan = NULL) {
 #'   tab. Default is `currentColor`.
 #' @param hover_foreground The text color of a hovered panel tab. Default is
 #'   `currentColor`.
-#' @param tabs_border_bottom The border color between the tabs and content.
-#'   Default is `#ddd`.
+#' @param separator_color,tabs_border_bottom The border color between the tabs
+#'   and content. Default is `#ddd`. `tabs_border_bottom` is superseded by
+#'   `separator_color` but is kept for backwards compatibility.
 #' @param tabs_sideways_max_width The maximum width of the tabs in sideways
 #'   mode. The default value is `25%`. A value between 25% and 33% is
 #'   recommended. The tabs can only ever be at most 50% of the container width.
@@ -76,8 +77,10 @@ use_panelset <- function(in_xaringan = NULL) {
 #'   a tab when it is active or the color of the bottom border of a tab when it
 #'   is hovered or focused. Defaults are `currentColor`.
 #' @param selector The CSS selector used to choose which panelset is being
-#'   styled. In most cases, you can use the default selector and style all
-#'   panelsets on the page.
+#'   styled. In most cases, you can use the default selector to style all
+#'   panelsets on the page. When `selector` is `NULL`, `style_panelset()` will
+#'   return the styles without wrapping them in a `<style>` tag so they can be
+#'   used in inline styles.
 #' @export
 style_panelset_tabs <- function(
   foreground = NULL,
@@ -89,6 +92,7 @@ style_panelset_tabs <- function(
   hover_background = NULL,
   hover_foreground = NULL,
   hover_border_color = NULL,
+  separator_color = NULL,
   tabs_border_bottom = NULL,
   tabs_sideways_max_width = NULL,
   inactive_opacity = NULL,
@@ -97,8 +101,8 @@ style_panelset_tabs <- function(
 ) {
   if (length(list(...))) {
     warning(
-      "The arguments to `syle_panelset()` changed in xaringanExtra 0.1.0. ",
-      "Please refer to the documentation to update your slides.",
+      "The argument names of `style_panelset()` changed in xaringanExtra 0.1.0. ",
+      "Please refer to the documentation to update to the latest names.",
       immediate. = TRUE
     )
   }
@@ -118,10 +122,12 @@ style_panelset_tabs <- function(
     args["--panel-tab-font-family"] <- "Menlo, Consolas, Monaco, Liberation Mono, Lucida Console, monospace"
   }
 
-  style <- ""
-  for (var in names(args)) {
-    style <- paste0(style, var, ": ", args[var], ";")
+  style <- htmltools::css(!!!args)
+
+  if (is.null(selector)) {
+    return(htmltools::HTML(style))
   }
+
   style <- paste0("<style>", selector, "{", style, "}</style>")
   htmltools::HTML(style)
 }
@@ -144,6 +150,7 @@ panelset_match_vars <- function(x = NULL) {
     hover_background = "--panel-tab-hover-background",
     hover_foreground = "--panel-tab-hover-foreground",
     hover_border_color = "--panel-tab-hover-border-color",
+    separator_color = "--panel-tabs-separator-color",
     tabs_border_bottom = "--panel-tabs-border-bottom",
     inactive_opacity = "--panel-tab-inactive-opacity",
     font_family = "--panel-tab-font-family",

--- a/R/panelset.R
+++ b/R/panelset.R
@@ -97,7 +97,7 @@ style_panelset_tabs <- function(
   tabs_sideways_max_width = NULL,
   inactive_opacity = NULL,
   font_family = NULL,
-  selector = ".panelset"
+  selector = ":root"
 ) {
   if (length(list(...))) {
     warning(

--- a/R/panelset.R
+++ b/R/panelset.R
@@ -112,7 +112,7 @@ style_panelset_tabs <- function(
   args <- lapply(fn_args, function(x) get(x))
   args <- args[vapply(args, function(x) !is.null(x), TRUE)]
   if (!length(args)) {
-    return(invisible(NULL))
+    return(NULL)
   }
 
   names(args) <- panelset_match_vars(names(args))

--- a/inst/panelset/panelset.css
+++ b/inst/panelset/panelset.css
@@ -1,4 +1,9 @@
-/* prefixed by https://autoprefixer.github.io (PostCSS: v7.0.23, autoprefixer: v9.7.3) */
+/*
+* Prefixed by https://autoprefixer.github.io
+* PostCSS: v8.4.14,
+* Autoprefixer: v10.4.7
+* Browsers: >0.3%,last 2 versions,not dead
+*/
 
 .panelset {
   width: 100%;
@@ -22,16 +27,11 @@
 }
 
 .panelset .panel-tabs {
-  display: -webkit-box;
   display: flex;
   flex-wrap: wrap;
-  -webkit-box-orient: horizontal;
-  -webkit-box-direction: normal;
-          flex-direction: row;
-  -webkit-box-pack: start;
-          justify-content: start;
-  -webkit-box-align: center;
-          align-items: center;
+  flex-direction: row;
+  justify-content: start;
+  align-items: center;
   overflow-y: visible;
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
@@ -40,18 +40,14 @@
 }
 
 .panelset .panel-tabs * {
-  -webkit-transition: opacity 0.5s ease;
   transition: opacity 0.5s ease;
 }
 
 .panelset .panel-tabs .panel-tab {
   min-height: 50px;
-  display: -webkit-box;
   display: flex;
-  -webkit-box-pack: center;
-          justify-content: center;
-  -webkit-box-align: center;
-          align-items: center;
+  justify-content: center;
+  align-items: center;
   padding: 0.5em 1em;
   font-family: var(--panel-tab-font-family);
   opacity: var(--panel-tab-inactive-opacity);

--- a/inst/panelset/panelset.css
+++ b/inst/panelset/panelset.css
@@ -8,18 +8,35 @@
 .panelset {
   width: 100%;
   position: relative;
-  --panel-tabs-border-bottom: #ddd;
-  --panel-tabs-sideways-max-width: 25%;
-  --panel-tab-foreground: currentColor;
-  --panel-tab-background: unset;
-  --panel-tab-active-foreground: currentColor;
-  --panel-tab-active-background: unset;
-  --panel-tab-hover-foreground: currentColor;
-  --panel-tab-hover-background: unset;
-  --panel-tab-active-border-color: currentColor;
-  --panel-tab-hover-border-color: currentColor;
-  --panel-tab-inactive-opacity: 0.5;
-  --panel-tab-font-family: inherit;
+  --_tabs-separator-color: var(--panel-tabs-separator-color, var(--panel-tabs-border-bottom, #ddd));
+  --_tabs-separator-width: var(--panel-tabs-separator-width, 2px);
+  --_tabs-separator: var(--_tabs-separator-width) solid var(--_tabs-separator-color);
+  --_tabs-sideways-max-width: var(--panel-tabs-sideways-max-width, 25%);
+  --_tabs-spacing: var(--panel-tabs-spacing, 0);
+
+  --_foreground: var(--panel-tab-foreground, currentColor);
+  --_background: var(--panel-tab-background, unset);
+  --_active-foreground: var(--panel-tab-active-foreground, currentColor);
+  --_active-background: var(--panel-tab-active-background, unset);
+  --_hover-foreground: var(--panel-tab-hover-foreground, currentColor);
+  --_hover-background: var(--panel-tab-hover-background, unset);
+
+  --_border-color: var(--panel-tab-border-color, transparent);
+  --_border-top-color: var(--panel-tab-border-top-color, var(--_border-color));
+  --_border-bottom-color: var(--panel-tab-border-bottom-color, var(--_border-color));
+  --_border-width: var(--_tabs-separator-width) 0;
+  --_border-radius: var(--panel-tab-border-radius, 0);
+
+  --_active-border-color: var(--panel-tab-active-border-color, currentColor);
+  --_active-border-top-color: var(--panel-tab-active-border-top-color, var(--_active-border-color));
+  --_active-border-bottom-color: var(--panel-tab-active-border-bottom-color, var(--_active-border-color));
+
+  --_hover-border-top-color: var(--panel-tab-hover-border-top-color, transparent);
+  --_hover-border-bottom-color: var(--panel-tab-hover-border-bottom-color, currentColor);
+
+  --_inactive-opacity: var(--panel-tab-inactive-opacity, 0.5);
+  --_font-family: var(--panel-tab-font-family, inherit);
+  --_transition-duration: var(--panel-tab-transition-duration, 0.5s);
 }
 
 .panelset * {
@@ -32,15 +49,14 @@
   flex-direction: row;
   justify-content: start;
   align-items: center;
-  overflow-y: visible;
-  overflow-x: auto;
-  -webkit-overflow-scrolling: touch;
-  padding: 0 0 2px 0;
-  box-shadow: inset 0 -2px 0px var(--panel-tabs-border-bottom);
+  overflow: visible;
+  padding: 0;
+  gap: var(--_tabs-spacing);
+  border-bottom: var(--_tabs-separator);
 }
 
 .panelset .panel-tabs * {
-  transition: opacity 0.5s ease;
+  transition: opacity var(--_transition-duration) ease;
 }
 
 .panelset .panel-tabs .panel-tab {
@@ -49,13 +65,16 @@
   justify-content: center;
   align-items: center;
   padding: 0.5em 1em;
-  font-family: var(--panel-tab-font-family);
-  opacity: var(--panel-tab-inactive-opacity);
-  border-top: 2px solid transparent;
-  border-bottom: 2px solid transparent;
-  margin-bottom: -2px;
-  color: var(--panel-tab-foreground);
-  background-color: var(--panel-tab-background);
+  font-family: var(--_font-family);
+  opacity: var(--_inactive-opacity);
+  border-width: var(--_border-width);
+  border-style: solid;
+  border-radius: var(--_border-radius);
+  border-top-color: var(--_border-top-color);
+  border-bottom-color: var(--_border-bottom-color);
+  margin-bottom: calc(-1 * var(--_tabs-separator-width));
+  color: var(--_foreground);
+  background-color: var(--_background);
   list-style: none;
   z-index: 5;
 }
@@ -79,10 +98,15 @@
   border: none;
 }
 
+.panelset .panel-tabs .panel-tab:hover,
+.panelset .panel-tabs .panel-tab:focus {
+  --_border-top-color: var(--_hover-border-top-color);
+  --_border-bottom-color: var(--_hover-border-bottom-color);
+  --_foreground: var(--_hover-foreground);
+  --_background: var(--_hover-background);
+}
+
 .panelset .panel-tabs .panel-tab:hover {
-  border-bottom-color: var(--panel-tab-hover-border-color);
-  color: var(--panel-tab-hover-foreground);
-  background-color: var(--panel-tab-hover-background);
   opacity: 1;
   cursor: pointer;
   z-index: 10;
@@ -90,15 +114,13 @@
 
 .panelset .panel-tabs .panel-tab:focus {
   outline: none;
-  color: var(--panel-tab-hover-foreground);
-  border-bottom-color: var(--panel-tab-hover-border-color);
-  background-color: var(--panel-tab-hover-background);
 }
 
 .panelset .panel-tabs .panel-tab.panel-tab-active {
-  border-top-color: var(--panel-tab-active-border-color);
-  color: var(--panel-tab-active-foreground);
-  background-color: var(--panel-tab-active-background);
+  --_foreground: var(--_active-foreground);
+  --_background: var(--_active-background);
+  --_border-top-color: var(--_active-border-top-color);
+  --_border-bottom-color: var(--_active-border-bottom-color);
   opacity: 1;
 }
 
@@ -121,15 +143,16 @@
   .panelset.sideways .panel-tabs {
     box-shadow: none;
     flex-direction: column;
-    align-items: start;
+    align-items: stretch;
     margin: 0;
     margin-right: 1em;
-    border-right: 2px solid var(--panel-tabs-border-bottom);
-    max-width: var(--panel-tabs-sideways-max-width);
+    border-right: var(--_tabs-separator);
+    border-bottom: unset;
+    max-width: var(--_tabs-sideways-max-width);
   }
 
   .panelset.sideways .panel {
-    max-width: calc(100% - var(--panel-tabs-sideways-max-width) - 1em);
+    max-width: calc(100% - var(--_tabs-sideways-max-width) - 1em);
   }
 
   .panelset.sideways .panel-tabs .panel-tab {
@@ -138,21 +161,28 @@
     padding-left: 0;
   }
 
+  .panelset.sideways:not(.right) .panel-tabs .panel-tab {
+    text-align: left;
+    border-right: var(--_tabs-separator-width) solid var(--_border-bottom-color);
+    margin-right: calc(-1 * var(--_tabs-separator-width));
+  }
+
+  .panelset.sideways.right .panel-tabs .panel-tab {
+    text-align: right;
+    border-left: var(--_tabs-separator-width) solid var(--_border-bottom-color);
+    margin-left: calc(-1 * var(--_tabs-separator-width));
+  }
+
   .panelset.sideways.right {
     flex-direction: row-reverse;
     justify-content: space-between;
   }
 
-  .panelset.sideways.right {
-  	text-align: inherit;
-  }
-
   .panelset.sideways.right .panel-tabs {
-    align-items: end;
     margin-right: 0;
     margin-left: 1em;
     border-right: unset;
-    border-left: 2px solid var(--panel-tabs-border-bottom);
+    border-left: var(--_tabs-separator);
   }
 
   .panelset.sideways.right .panel-tabs .panel-tab {
@@ -168,7 +198,7 @@
 /*
   This next part repeats the same CSS inside the @media query above but with
   remarkjs-specific classes to ensure that sideways panelsets are always used.
-  In the future, we could use @container queries instead once they're availble.
+  In the future, we could use CSS nesting instead once it's availble.
 */
 
 .remark-container .panelset.sideways {
@@ -179,15 +209,16 @@
 .remark-container .panelset.sideways .panel-tabs {
   box-shadow: none;
   flex-direction: column;
-  align-items: start;
+  align-items: stretch;
   margin: 0;
   margin-right: 1em;
-  border-right: 2px solid var(--panel-tabs-border-bottom);
-  max-width: var(--panel-tabs-sideways-max-width);
+  border-right: var(--_tabs-separator);
+  border-bottom: unset;
+  max-width: var(--_tabs-sideways-max-width);
 }
 
 .remark-container .panelset.sideways .panel {
-  max-width: calc(100% - var(--panel-tabs-sideways-max-width) - 1em);
+  max-width: calc(100% - var(--_tabs-sideways-max-width) - 1em);
 }
 
 .remark-container .panelset.sideways .panel-tabs .panel-tab {
@@ -196,21 +227,28 @@
   padding-left: 0;
 }
 
+.remark-container .panelset.sideways:not(.right) .panel-tabs .panel-tab {
+  text-align: left;
+  border-right: var(--_tabs-separator-width) solid var(--_border-bottom-color);
+  margin-right: calc(-1 * var(--_tabs-separator-width));
+}
+
+.remark-container .panelset.sideways.right .panel-tabs .panel-tab {
+  text-align: right;
+  border-left: var(--_tabs-separator-width) solid var(--_border-bottom-color);
+  margin-left: calc(-1 * var(--_tabs-separator-width));
+}
+
 .remark-container .panelset.sideways.right {
   flex-direction: row-reverse;
   justify-content: space-between;
 }
 
-.remark-container .panelset.sideways.right {
-	text-align: inherit;
-}
-
 .remark-container .panelset.sideways.right .panel-tabs {
-  align-items: end;
   margin-right: 0;
   margin-left: 1em;
   border-right: unset;
-  border-left: 2px solid var(--panel-tabs-border-bottom);
+  border-left: var(--_tabs-separator);
 }
 
 .remark-container .panelset.sideways.right .panel-tabs .panel-tab {

--- a/inst/panelset/panelset.css
+++ b/inst/panelset/panelset.css
@@ -132,6 +132,16 @@
   display: block;
 }
 
+.panelset .panel > :first-child,
+.panelset .panel > section:first-child > :first-child {
+  margin-top: 0;
+}
+
+.panelset .panel > :last-child,
+.panelset .panel > section:last-child > :last-child {
+  margin-bottom: 0;
+}
+
 /* ---- Sideways Panelset ---- */
 
 @media (min-width: 480px) {

--- a/man/panelset.Rd
+++ b/man/panelset.Rd
@@ -20,11 +20,12 @@ style_panelset_tabs(
   hover_background = NULL,
   hover_foreground = NULL,
   hover_border_color = NULL,
+  separator_color = NULL,
   tabs_border_bottom = NULL,
   tabs_sideways_max_width = NULL,
   inactive_opacity = NULL,
   font_family = NULL,
-  selector = ".panelset"
+  selector = ":root"
 )
 
 style_panelset(...)
@@ -55,8 +56,9 @@ is hovered or focused. Defaults are \code{currentColor}.}
 \item{hover_foreground}{The text color of a hovered panel tab. Default is
 \code{currentColor}.}
 
-\item{tabs_border_bottom}{The border color between the tabs and content.
-Default is \verb{#ddd}.}
+\item{separator_color, tabs_border_bottom}{The border color between the tabs
+and content. Default is \verb{#ddd}. \code{tabs_border_bottom} is superseded by
+\code{separator_color} but is kept for backwards compatibility.}
 
 \item{tabs_sideways_max_width}{The maximum width of the tabs in sideways
 mode. The default value is \verb{25\%}. A value between 25\% and 33\% is
@@ -68,8 +70,10 @@ recommended. The tabs can only ever be at most 50\% of the container width.}
 Default is a monospace system font stack.}
 
 \item{selector}{The CSS selector used to choose which panelset is being
-styled. In most cases, you can use the default selector and style all
-panelsets on the page.}
+styled. In most cases, you can use the default selector to style all
+panelsets on the page. When \code{selector} is \code{NULL}, \code{style_panelset()} will
+return the styles without wrapping them in a \verb{<style>} tag so they can be
+used in inline styles.}
 }
 \value{
 An \code{htmltools::tagList()} with the panelset dependencies, or an

--- a/tests/testthat/_snaps/panelset.md
+++ b/tests/testthat/_snaps/panelset.md
@@ -1,0 +1,7 @@
+# style_panelset_tabs
+
+    Code
+      css
+    Output
+      <style>.panelset{--panel-tab-foreground:var(--text-mild);--panel-tab-background:unset;--panel-tab-active-foreground:var(--text-dark);--panel-tab-active-background:var(--text-lightest);--panel-tab-active-border-color:var(--purple);--panel-tab-hover-background:#fafafa;--panel-tab-hover-border-color:var(--text-lightest);--panel-tabs-border-bottom:var(--text-mild);--panel-tab-inactive-opacity:1;}</style>
+

--- a/tests/testthat/_snaps/panelset.md
+++ b/tests/testthat/_snaps/panelset.md
@@ -1,7 +1,22 @@
 # style_panelset_tabs
 
     Code
-      css
+      style_panelset_tabs(foreground = "var(--text-mild)", background = "unset",
+        active_foreground = "var(--text-dark)", active_background = "var(--text-lightest)",
+        active_border_color = "var(--purple)", hover_background = "#fafafa",
+        hover_border_color = "var(--text-lightest)", inactive_opacity = 1,
+        separator_color = "var(--text-mild)")
     Output
       <style>:root{--panel-tab-foreground:var(--text-mild);--panel-tab-background:unset;--panel-tab-active-foreground:var(--text-dark);--panel-tab-active-background:var(--text-lightest);--panel-tab-active-border-color:var(--purple);--panel-tab-hover-background:#fafafa;--panel-tab-hover-border-color:var(--text-lightest);--panel-tabs-separator-color:var(--text-mild);--panel-tab-inactive-opacity:1;}</style>
+
+---
+
+    Code
+      style_panelset_tabs(foreground = "var(--text-mild)", background = "unset",
+        active_foreground = "var(--text-dark)", active_background = "var(--text-lightest)",
+        active_border_color = "var(--purple)", hover_background = "#fafafa",
+        hover_border_color = "var(--text-lightest)", inactive_opacity = 1,
+        separator_color = "var(--text-mild)", selector = NULL)
+    Output
+      --panel-tab-foreground:var(--text-mild);--panel-tab-background:unset;--panel-tab-active-foreground:var(--text-dark);--panel-tab-active-background:var(--text-lightest);--panel-tab-active-border-color:var(--purple);--panel-tab-hover-background:#fafafa;--panel-tab-hover-border-color:var(--text-lightest);--panel-tabs-separator-color:var(--text-mild);--panel-tab-inactive-opacity:1;
 

--- a/tests/testthat/_snaps/panelset.md
+++ b/tests/testthat/_snaps/panelset.md
@@ -3,5 +3,5 @@
     Code
       css
     Output
-      <style>.panelset{--panel-tab-foreground:var(--text-mild);--panel-tab-background:unset;--panel-tab-active-foreground:var(--text-dark);--panel-tab-active-background:var(--text-lightest);--panel-tab-active-border-color:var(--purple);--panel-tab-hover-background:#fafafa;--panel-tab-hover-border-color:var(--text-lightest);--panel-tabs-border-bottom:var(--text-mild);--panel-tab-inactive-opacity:1;}</style>
+      <style>:root{--panel-tab-foreground:var(--text-mild);--panel-tab-background:unset;--panel-tab-active-foreground:var(--text-dark);--panel-tab-active-background:var(--text-lightest);--panel-tab-active-border-color:var(--purple);--panel-tab-hover-background:#fafafa;--panel-tab-hover-border-color:var(--text-lightest);--panel-tabs-separator-color:var(--text-mild);--panel-tab-inactive-opacity:1;}</style>
 

--- a/tests/testthat/test-panelset.R
+++ b/tests/testthat/test-panelset.R
@@ -1,17 +1,34 @@
 test_that("style_panelset_tabs", {
-  css <- style_panelset_tabs(
-    foreground = "var(--text-mild)",
-    background = "unset",
-    active_foreground = "var(--text-dark)",
-    active_background = "var(--text-lightest)",
-    active_border_color = "var(--purple)",
-    hover_background = "#fafafa",
-    hover_border_color = "var(--text-lightest)",
-    inactive_opacity = 1,
-    separator_color = "var(--text-mild)"
+  expect_snapshot(
+    style_panelset_tabs(
+      foreground = "var(--text-mild)",
+      background = "unset",
+      active_foreground = "var(--text-dark)",
+      active_background = "var(--text-lightest)",
+      active_border_color = "var(--purple)",
+      hover_background = "#fafafa",
+      hover_border_color = "var(--text-lightest)",
+      inactive_opacity = 1,
+      separator_color = "var(--text-mild)"
+    )
   )
 
-  testthat::expect_snapshot(css)
+  expect_snapshot(
+    style_panelset_tabs(
+      foreground = "var(--text-mild)",
+      background = "unset",
+      active_foreground = "var(--text-dark)",
+      active_background = "var(--text-lightest)",
+      active_border_color = "var(--purple)",
+      hover_background = "#fafafa",
+      hover_border_color = "var(--text-lightest)",
+      inactive_opacity = 1,
+      separator_color = "var(--text-mild)",
+      selector = NULL
+    )
+  )
+
+  expect_warning(expect_null(style_panelset_tabs(foo = "bar")))
 })
 
 describe("panelset_source_opts()", {

--- a/tests/testthat/test-panelset.R
+++ b/tests/testthat/test-panelset.R
@@ -8,7 +8,7 @@ test_that("style_panelset_tabs", {
     hover_background = "#fafafa",
     hover_border_color = "var(--text-lightest)",
     inactive_opacity = 1,
-    tabs_border_bottom = "var(--text-mild)"
+    separator_color = "var(--text-mild)"
   )
 
   testthat::expect_snapshot(css)

--- a/tests/testthat/test-panelset.R
+++ b/tests/testthat/test-panelset.R
@@ -11,11 +11,7 @@ test_that("style_panelset_tabs", {
     tabs_border_bottom = "var(--text-mild)"
   )
 
-  # FIXME: convert to testthat 3e
-  expect_equal(
-    as.character(css),
-    "<style>.panelset{--panel-tab-foreground: var(--text-mild);--panel-tab-background: unset;--panel-tab-active-foreground: var(--text-dark);--panel-tab-active-background: var(--text-lightest);--panel-tab-active-border-color: var(--purple);--panel-tab-hover-background: #fafafa;--panel-tab-hover-border-color: var(--text-lightest);--panel-tabs-border-bottom: var(--text-mild);--panel-tab-inactive-opacity: 1;}</style>"
-  )
+  testthat::expect_snapshot(css)
 })
 
 describe("panelset_source_opts()", {


### PR DESCRIPTION
A few improvements all around:

* Simplify how the active tab border bottom is handled
* Use CSS pseudo-private properties
* Inherit global CSS custom properties on `:root` rather than scoped to `.panelset`
* Use testthat 3rd edition snapshots