### PR TITLE
Support panelset chunk in quarto documents

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,19 @@
   border of the active tab are handled. `style_panelset_tabs()` gains a new
   `separator_color` argument to replace `tabs_border_bottom` (#192).
 
+* **panelset** now fully supports panelset chunks in Quarto, either with
+  `#| panelset: true` for chunk options or the alternative syntax specifying the
+  panel names for the source and output panels (#193):
+
+  ````markdown
+  ```{r}
+  #| panelset:
+  #|  - source: The Code
+  #|  - output: The Result
+  rnorm(10)
+  ```
+  ````
+
 # xaringanExtra 0.7.0
 
 * BREAKING CHANGE: All arguments to `use_banner()` must be named. `use_banner()`

--- a/R/panelset.R
+++ b/R/panelset.R
@@ -282,7 +282,7 @@ panelset_chunk_before_xaringan <- function(x, options) {
     "",
     .hooks$source(x, options),
     "\n]\n",
-    sprintf(".panel[.panel-name[%s]", panelset_output),
+    sprintf(".panel[.panel-name[%s]", panel_output),
     "\n",
     sep = "\n"
   )

--- a/inst/panelset/panelset.css
+++ b/inst/panelset/panelset.css
@@ -137,11 +137,6 @@
   margin-top: 0;
 }
 
-.panelset .panel > :last-child,
-.panelset .panel > section:last-child > :last-child {
-  margin-bottom: 0;
-}
-
 /* ---- Sideways Panelset ---- */
 
 @media (min-width: 480px) {

--- a/inst/panelset/panelset.js
+++ b/inst/panelset/panelset.js
@@ -294,6 +294,10 @@
     }
 
     // initialize panels
+    document
+      .querySelectorAll('[data-panelset="true"]')
+      .forEach(el => el.classList.add('panelset'))
+
     Array.from(document.querySelectorAll('.panelset')).map(initPanelSet)
 
     if (typeof slideshow !== 'undefined') {


### PR DESCRIPTION
Improve support for panelset chunks in quarto documents:

1. Treat `[data-panelset="true"]` the same as `.panelset` (by adding the class before initializing panelsets). Quarto takes the unknown `paneset` chunk option and keeps it as a data attribute, so this picks up there.

2. Switch to using knitr chunk options for the panel source and output labels, so that `[data-panelset="true"]` is always the attribute applied to the panelset chunks. The knitr hooks pick up the panel source and output names.