### PR TITLE
panelset: Fully support nested panelsets

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,37 @@
   ```
   ````
 
+* Nested **panelsets** are now supported (#194)! In xaringan slides and when
+  using the hand-rolled panelset syntax, you can now nest panelsets within
+  panelsets. In R Markdown or Quarto documents, panelsets chunks can be nested
+  within panelset sections. Nesting panelset sections requires the fenced div
+  syntax:
+
+  ````markdown
+  # Nested fenced divs
+
+  ::: {.panelset #outer}
+
+  ## One
+
+  Outer panel One.
+
+  ::: {.panelset #inner}
+  ### One A
+
+  Inner panel One A.
+
+  ### One B
+
+  Inner panel One B.
+  :::
+
+  ## Two
+
+  Outer panel Two.
+  :::
+  ````
+
 # xaringanExtra 0.7.0
 
 * BREAKING CHANGE: All arguments to `use_banner()` must be named. `use_banner()`


### PR DESCRIPTION
Fixes #86

Also use panelset ID instead of generated ID, if available,
and improve the panelset ID generation.

Nested panelsets are now supported in general with hand-rolled markup. In R Markdown or Quarto documents, nested panelsets are possible using the fenced div syntax:

```markdown
# Nested fenced divs

::: {.panelset #outer}

## One

Pariatur dolor est pariatur excepteur ad consectetur anim veniam sit ad laboris ad commodo Lorem.

::: {.panelset #inner}
### One A

Et duis nulla sunt eu elit est incididunt qui. Occaecat ullamco ad ut ipsum quis sunt dolor aute amet eiusmod. Ad mollit voluptate consequat exercitation culpa dolore culpa adipisicing.

### One B

Officia ea eu ad sunt ullamco consectetur nisi cillum culpa consequat sit esse ad. Reprehenderit incididunt eiusmod est sint amet ad pariatur reprehenderit in officia. Ipsum exercitation ad quis non ex mollit dolore.
:::

## Two

Exercitation proident consequat velit officia irure incididunt veniam.
:::
```

