### PR TITLE
fix: Apply `margin-top` to `.panel` instead of `margin-bottom` to `.panel-tabs`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Fixed an issue that caused panelset to incorrectly apply classes from the `.panel` markup container (#200).
 
+* Panelset now applies margin spacing between tabs and panels as `margin-top` on the `.panel` element, rather than `margin-bottom` on the `.panel-tabs` container. This lets you control the spacing between tabs and panel using classes on the `.panel` container (#202).
+
 # xaringanExtra 0.8.0
 
 This release focuses entirely on improving the **panelset** feature, especially

--- a/_extensions/panelset/panelset.css
+++ b/_extensions/panelset/panelset.css
@@ -58,6 +58,7 @@
   padding: 0;
   gap: var(--_tabs-spacing);
   border-bottom: var(--_tabs-separator);
+  margin-bottom: 0;
 }
 
 .panelset .panel-tabs * {
@@ -139,6 +140,7 @@
 
 .panelset .panel {
   display: none;
+  margin-top: 1rem;
 }
 
 .panelset .panel-active {

--- a/inst/panelset/panelset.css
+++ b/inst/panelset/panelset.css
@@ -58,6 +58,7 @@
   padding: 0;
   gap: var(--_tabs-spacing);
   border-bottom: var(--_tabs-separator);
+  margin-bottom: 0;
 }
 
 .panelset .panel-tabs * {
@@ -139,6 +140,7 @@
 
 .panelset .panel {
   display: none;
+  margin-top: 1rem;
 }
 
 .panelset .panel-active {


### PR DESCRIPTION
This will now work as expected

````
::: panelset
::: {.panel name="Install" .m-0 .p-3 .border .border-1}
Install xaringanExtra from [CRAN][cr] in the usual way.

```{.r}
install.packages("xaringanExtra")
```

Or install the development version from [GitHub][gh] or [r-universe][ru].

```{.r}
pak::pak("gadenbuie/xaringanExtra")
```

```{.r}
install.packages("xaringanExtra", repos = c("https://gadenbuie.r-universe.dev", "https://cran.r-project.org"))
```
:::
:::
````